### PR TITLE
fix: :bug: coloring for all HB commands

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -163,8 +163,10 @@ let coq_gallina_keywords = mkset [
 ]
 
 let mathcomp_hierarchy_builders = mkset [
-  "HB.instance"; "HB.builders"; "HB.factory"; "HB.mixin";
-  "HB.structure"
+  "HB.check"; "HB.locate"; "HB.about"; "HB.howto";
+  "HB.status"; "HB.graph"; "HB.mixin"; "HB.structure";
+  "HB.saturate"; "HB.instance"; "HB.factory"; "HB.builders";
+  "HB.end"; "HB.export"; "HB.reexport"; "HB.declare";
 ]
 
 (** HTML generation *)


### PR DESCRIPTION
issue: https://github.com/affeldt-aist/coq2html/issues/13

Color following HB commands:
```
  "HB.check"; "HB.locate"; "HB.about"; "HB.howto";
  "HB.status"; "HB.graph"; "HB.mixin"; "HB.structure";
  "HB.saturate"; "HB.instance"; "HB.factory"; "HB.builders";
  "HB.end"; "HB.export"; "HB.reexport"; "HB.declare";
```