### PR TITLE
fix: link name of notations

### DIFF
--- a/generate_index.mli
+++ b/generate_index.mli
@@ -2,6 +2,8 @@ type xref =
   | Defs of (string * string) list
   | Ref of string * string * string
 
-val html_escape : string -> string
+val escaped : string -> string
+
+val sanitize_linkname : string -> string
 
 val generate : string -> (string * int, xref) Hashtbl.t -> (string, unit) Hashtbl.t -> unit


### PR DESCRIPTION
fixes #8 

Make link name of notations MD5 hash string if the path contains characters other than alphabets, number, or some symbols.
This behavior is same as current coqdoc implementation.

## spec

Paths consisting only of the following characters will not be hashed:

* alphabets: `a`..`z` and `A`..`Z`
* numbers `0`..`9`
* `.`, `_`
* `<`, `>`, `&`, `'`, `"`
* `-`, `:`

## reference implementation of coqdoc

https://github.com/coq/coq/blob/v8.19/tools/coqdoc/output.ml#L617

## issues
* https://github.com/affeldt-aist/coq2html/issues/8
