### PR TITLE
fix: :bug: missing purple vernacular keywords.

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -150,6 +150,8 @@ let coq_vernaculars = mkset [
   "Require"; "Reserved"; "Scheme"; "Scope"; "Section";
   "Strategy"; "Structure"; "SubClass"; "Tactic"; "Theorem";
   "Transparent"; "Universe"; "Variable"; "Variables"; "Variant";
+  "Unset"; "Strict"; "Printing"; "Defensive"; "Number"; "Declare";
+  "Delimit"; "Bind"; "Local";
 ]
 
 let coq_gallina_keywords = mkset [


### PR DESCRIPTION
fixes #7 

add following keywords as vernacular words:
```
  "Unset"; "Strict"; "Printing"; "Defensive"; "Number"; "Declare";
  "Delimit"; "Bind"; "Local";
```

## issue
* https://github.com/affeldt-aist/coq2html/issues/7