### PR TITLE
feat: introduce `-title` option for the title of index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 In the case using in mathcomp analysis directory:
 ```console
 ../coq2html/coq2html \\
+  -title "Mathcomp Analysis" \\
   -d html/ -base mathcomp -Q theories analysis \\
   -coqlib https://coq.inria.fr/doc/V8.18.0/stdlib/ \\
   -external https://math-comp.github.io/htmldoc/ mathcomp.ssreflect \\

--- a/coq2html.mll
+++ b/coq2html.mll
@@ -545,6 +545,7 @@ let make_redirect fromfile toURL =
     (global_replace (Str.regexp "\\$URL") toURL Resources.redirect);
   close_out oc
 
+let title = ref ""
 let output_dir = ref Filename.current_dir_name
 let logical_name_base = ref ""
 let generate_css = ref true
@@ -591,6 +592,8 @@ let _ =
       eprintf "Don't know what to do with file %s\n" f; exit 2
     end in
   Arg.parse (Arg.align [
+    "-title", Arg.String (fun s -> title := s),
+      "<title>  Set the title of the index.html";
     "-base", Arg.String (fun s -> logical_name_base := s ^ "."),
       "<coqdir>  Set the name space for the modules being processed";
     "-coqlib", Arg.String (fun s -> add_documentation_url "Coq" s),
@@ -630,7 +633,7 @@ let _ =
   end;
   List.iter process_glob_file (List.rev !glob_files);
   List.iter process_v_file (List.rev !v_files);
-  Generate_index.generate !output_dir xref_table xref_modules;
+  Generate_index.generate !output_dir xref_table xref_modules !title;
   write_file Resources.js (Filename.concat !output_dir "coq2html.js");
   if !generate_css then
     write_file Resources.css (Filename.concat !output_dir "coq2html.css")

--- a/coq2html.mll
+++ b/coq2html.mll
@@ -545,7 +545,9 @@ let make_redirect fromfile toURL =
     (global_replace (Str.regexp "\\$URL") toURL Resources.redirect);
   close_out oc
 
-let title = ref ""
+let default_title () = Filename.basename @@ Sys.getcwd ()
+
+let title = ref (default_title ())
 let output_dir = ref Filename.current_dir_name
 let logical_name_base = ref ""
 let generate_css = ref true

--- a/generate_index.ml
+++ b/generate_index.ml
@@ -38,9 +38,10 @@ let alphabets = (* ['A'; ...; 'Z'; '_'] *)
   in
   List.rev ('*' :: '_' :: iter (Char.code 'A') [])
 
-let write_html_file txt filename =
+let write_html_file txt filename title =
   let oc = open_out filename in
-  output_string oc (Str.global_replace (Str.regexp "<h1.*</h1>") "" Resources.header);
+  output_string oc (Str.global_replace (Str.regexp "<title>.*</title>") (!%"<title>%s</title>" title)
+                      (Str.global_replace (Str.regexp "<h1.*</h1>") "" Resources.header));   
   output_string oc txt;
   output_string oc Resources.footer;
   close_out oc
@@ -153,12 +154,13 @@ let generate_with_capital output_dir table kind (c, items) =
       |> String.concat "<br>"
       |> (^) (!%"%s<h2>%s</h2>" table h2)
     in
-    write_html_file body (Filename.concat output_dir (!%"index_%s_%c.html" (linkname_of_kind kind) c))
+    let title = !%"%C (%s)" c (skind kind) in
+    write_html_file body (Filename.concat output_dir (!%"index_%s_%c.html" (linkname_of_kind kind) c)) title
 
 (* generate index.html *)
-let generate_topfile output_dir xrefs =
+let generate_topfile output_dir xrefs title =
   let body = table xrefs in
-  write_html_file body (Filename.concat output_dir "index.html")
+  write_html_file body (Filename.concat output_dir "index.html") title
 
 let is_initial c s =
   if s = "" then false else
@@ -170,7 +172,7 @@ let is_initial c s =
     | _, _ -> false
 
 
-let generate output_dir xref_table xref_modules =
+let generate output_dir xref_table xref_modules title =
   let indexed_items =
     List.map (fun c ->
         let items =
@@ -201,5 +203,5 @@ let generate output_dir xref_table xref_modules =
   List.iter (fun kind ->
       List.iter (generate_with_capital output_dir (table indexed_items) kind) indexed_items)
     kinds;
-  generate_topfile output_dir indexed_items
+  generate_topfile output_dir indexed_items title
 

--- a/generate_index.mli
+++ b/generate_index.mli
@@ -6,4 +6,4 @@ val escaped : string -> string
 
 val sanitize_linkname : string -> string
 
-val generate : string -> (string * int, xref) Hashtbl.t -> (string, unit) Hashtbl.t -> unit
+val generate : string -> (string * int, xref) Hashtbl.t -> (string, unit) Hashtbl.t -> string -> unit


### PR DESCRIPTION
fix #6 

A new command line `-title` are introduced for the title of the `index.html`. If the is not specified, the directory name is chosed as the title.

## issue
* https://github.com/affeldt-aist/coq2html/issues/6