### PR TITLE
introduce -fragile-mathcomp-break

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -20,6 +20,8 @@ open Generate_index
 
 let current_module = ref ""
 
+let fragile_mathcomp_break = ref false
+
 (* Record cross-references found in .glob files *)
 
 (* (name of module, character position in file) -> cross-reference *)
@@ -543,7 +545,10 @@ and ssr_doc_bol = parse
 
 and ssr_doc = parse
   | "*)"
-      { ssr_doc lexbuf }
+      {
+        if !fragile_mathcomp_break then character ' ';
+        ssr_doc lexbuf
+      }
   | "\n"
       { character '\n'; ssr_doc_bol lexbuf }
   | eof
@@ -666,7 +671,9 @@ let _ =
     "-redirect", Arg.Set generate_redirects,
       "   Generate redirection files modname.html -> coqdir.modname.html";
     "-short-names", Arg.Set use_short_names,
-      "   Use short, unqualified module names in the output"
+      "   Use short, unqualified module names in the output";
+    "-fragile-mathcomp-break", Arg.Unit (fun () -> fragile_mathcomp_break := true),
+      "   Always put two spaces at the end of lines in markdown mode";
   ])
   process_file
   "Usage: coq2html [options] file.glob ... file.v ...\nOptions are:";


### PR DESCRIPTION
Always put two spaces at the end of lines in markdown mode when the `-fragile-mathcomp-break` option is given.

# Issue
- https://github.com/affeldt-aist/coq2html/issues/32