### PR TITLE
Fix #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Option                     | Summary
 `-short-names`             | Use short, unqualified module names in the output
 `-title` _TITLE_           | Set the title of the index page
 `-Q` _DIR_ _COQDIR_        | Map the directory _DIR_ to correspond to the module name _COQDIR_ (similar to `coqc`)
-`-fragile-mathcomp-break`  | In framed Mardown documentation comment, always put two spaces at the end of a line
-
 
 ### Usage example
 

--- a/coq2html.mll
+++ b/coq2html.mll
@@ -20,8 +20,6 @@ open Generate_index
 
 let current_module = ref ""
 
-let fragile_mathcomp_break = ref false
-
 (* Record cross-references found in .glob files *)
 
 (* (name of module, character position in file) -> cross-reference *)
@@ -524,7 +522,7 @@ and doc = parse
       { character c; doc lexbuf }
 
 and custom_mode = parse
-  | "*)"
+  | space* "*)"
       { () }
   | eof
       { () }
@@ -544,11 +542,8 @@ and ssr_doc_bol = parse
       { ssr_doc lexbuf }
 
 and ssr_doc = parse
-  | "*)"
-      {
-        if !fragile_mathcomp_break then character ' ';
-        ssr_doc lexbuf
-      }
+  | space* "*)"
+      { ssr_doc lexbuf }
   | "\n"
       { character '\n'; ssr_doc_bol lexbuf }
   | eof
@@ -672,8 +667,6 @@ let _ =
       "   Generate redirection files modname.html -> coqdir.modname.html";
     "-short-names", Arg.Set use_short_names,
       "   Use short, unqualified module names in the output";
-    "-fragile-mathcomp-break", Arg.Unit (fun () -> fragile_mathcomp_break := true),
-      "   Always put two spaces at the end of lines in markdown mode";
   ])
   process_file
   "Usage: coq2html [options] file.glob ... file.v ...\nOptions are:";


### PR DESCRIPTION
This offers to fix https://github.com/affeldt-aist/coq2html/issues/17 by wiping out all end of line white spaces in block comments. The drawback is that the end-of-line-two-spaces "  " syntax of markdown to force line breaks is no longer available in block comments. But at least we get a nice and consistent output. The end-of-line-backslash "\" syntax for line breaks remains available.