### PR TITLE
refactor: :bug: :recycle: eliminate the occurrence of warnings issue #44

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -169,7 +169,7 @@ let crossref m pos max_pos =
         Link (snd range + 1, url ^ "#" ^ (sanitize_linkname p))
   | None ->
     let rec search_next pos =
-      eprintf "[search_next %d %d]" pos; flush stderr;
+      eprintf "[search_next %d]" pos; flush stderr;
       if pos > max_pos then None
       else if Hashtbl.find_opt xref_table (m, pos) = None then
         search_next (pos + 1)
@@ -442,20 +442,20 @@ rule coq_bol = parse
 	comment lexbuf;
         if !in_proof then coq lexbuf else skip_newline lexbuf }
   (* Enter verbatim mode *)
-  | space* ("(***" "*"+ "***)" "\n" as s)
+  | space* ("(***" "*"+ "***)" "\n")
       { fprintf !oc "<pre class=\"ssrdoc\">\n";
         ssr_doc_bol lexbuf;
 	fprintf !oc "%s" "</pre>\n";
 	skip_newline lexbuf
       }
   (* Enter ssrdoc with special syntax mode e.g. markdown syntax *)
-  | space* ("(**" (['a'-'z' '-']+ as mode) "*"+ "***)" "\n" as s)
+  | space* ("(**" (['a'-'z' '-']+ as mode) "*"+ "***)" "\n")
       { fprintf !oc "<div class=\"ssrdoc %s\">\n" mode;
         ssr_doc_bol lexbuf;
 	fprintf !oc "%s" "</div>\n";
 	skip_newline lexbuf
       }
-  | space* ("(***" (['a'-'z' '-']+ as mode) "*"+ "***)" "\n" as s)
+  | space* ("(***" (['a'-'z' '-']+ as mode) "*"+ "***)" "\n")
       { fprintf !oc "<div class=\"ssrdoc %s\">\n" mode;
         ssr_doc_bol lexbuf;
 	fprintf !oc "%s" "</div>\n";
@@ -588,7 +588,7 @@ and custom_mode = parse
 (* beginning of line *)
 and ssr_doc_bol = parse
   (* Leave verbatim mode *)
-  | space* ("(***" "*"+ "***)" as s)
+  | space* ("(***" "*"+ "***)")
       { () }
   | "(* "
       { ssr_doc_bol lexbuf }

--- a/generate_index.ml
+++ b/generate_index.ml
@@ -231,6 +231,8 @@ let all_files xref_modules =
          |> iter
        in
        Dir (dir_name, fs) :: iter rest
+    | [] :: _ ->
+      failwith "Generate_index.all_files: Please report: This is an unexpected case."
   in
   Hashtbl.to_seq_keys xref_modules
   |> List.of_seq


### PR DESCRIPTION
Eliminate the occurrence of warnings when compiling.

## Before

```coq
ocamlopt -c generate_index.mli
(for i in header footer css js redirect; do \
         echo "let $i = {xxx|"; \
         cat coq2html.$i; \
         echo '|xxx}'; \
         done) > resources.ml
ocamllex coq2html.mll
ocamlopt -c resources.ml
260 states, 6890 transitions, table size 29120 bytes
14060 additional bytes used for bindings
ocamlopt -c generate_index.ml
ocamlopt -c coq2html.ml
File "coq2html.mll", line 172, characters 6-39:
Warning 5 [ignored-partial-application]: this function application is partial,
maybe some arguments are missing.
File "generate_index.ml", lines 221-233, characters 17-38:
221 | .................function
222 |     | [] -> []
223 |     | [single_name] :: rest ->
224 |        File single_name :: iter rest
225 |     | (dir_name :: path) :: rest ->
...
230 |          (path :: List.map List.tl brothers)
231 |          |> iter
232 |        in
233 |        Dir (dir_name, fs) :: iter rest
Warning 8 [partial-match]: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
[]::_
File "coq2html.mll", line 445, characters 39-40:
Warning 26 [unused-var]: unused variable s.
File "coq2html.mll", line 452, characters 63-64:
Warning 26 [unused-var]: unused variable s.
File "coq2html.mll", line 458, characters 64-65:
Warning 26 [unused-var]: unused variable s.
File "coq2html.mll", line 591, characters 34-35:
Warning 26 [unused-var]: unused variable s.
```

## After

```
ocamlopt -c generate_index.mli
(for i in header footer css js redirect; do \
         echo "let $i = {xxx|"; \
         cat coq2html.$i; \
         echo '|xxx}'; \
         done) > resources.ml
ocamlopt -c resources.ml
ocamlopt -c generate_index.ml
ocamllex coq2html.mll
260 states, 6890 transitions, table size 29120 bytes
14157 additional bytes used for bindings
ocamlopt -c coq2html.ml
ocamlopt -o coq2html str.cmxa resources.cmx generate_index.cmx coq2html.cmx
rm coq2html.ml
```
## Issue

- https://github.com/affeldt-aist/coq2html/issues/44