### PR TITLE
fix :bug: #58

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -409,7 +409,7 @@ let quoted = ['\"'] ([' ' '!' '#'-'~'] | utf8)* ['\"']
 let symbol = ['!' '#'-'\'' '*'-'-' '/' ':'-'@' '['-'`' '{'-'~'] (*'"', '(', ')' *)
 let non_whites = (['A'-'Z' 'a'-'z' '0'-'9'] | symbol | utf8)+
 
-let xref = (['A'-'Z' 'a'-'z' '0'-'9' '#'-'~'] | utf8)+ | "<>"
+let xref = (['A'-'Z' 'a'-'z' '0'-'9' '!' '#'-'~'] | utf8)+ | "<>"
 let integer = ['0'-'9']+
 
 rule coq_bol = parse


### PR DESCRIPTION
Resolved #58 

The reason why issue58's `!=` was not correctly converted to a link because the `!` symbol was not included in the parsing of the glob file. Not only the `!=` reference, but all references containing `!` was not read from the glob file.