### PR TITLE
feat: :sparkles: introduce `--style` option for ocamldot

### DIFF
--- a/ocamldot/ocamldot.mll
+++ b/ocamldot/ocamldot.mll
@@ -307,6 +307,7 @@ let usage = "Usage: ocamldot [options] <files>"
 
 let leftToRight = ref false
 let roots = ref []
+let style = ref "bgcolor=transparent;\n  splines=true;\n  nodesep=1;\n  node [fontsize=18, shape=rect, color=\"#dbc3b6\", style=filled];"
 ;;
 
 Arg.parse
@@ -319,7 +320,10 @@ Arg.parse
      "         draw graph from left to right (default is top to bottom)");
     ("-r",
      Arg.String(fun s -> roots := s::!roots),
-     "<r>       use <r> as a root in the graph; nodes reachable from <r>\n               will be shown")
+     "<r>       use <r> as a root in the graph; nodes reachable from <r>\n               will be shown");
+    ("--style", Arg.Set_string style,
+     "     style of the graph")
+
   ]
   getDependFromFile usage;
 if not(!calledOnFile) then getDependFromStdin();
@@ -327,7 +331,7 @@ print_string "digraph depend {\n";
 print_string "  dpi = 48;\n";
 if (!leftToRight) then print_string "  rankdir = LR ;\n"
 else print_string "  rankdir = TB ;\n";
-print_string "bgcolor=transparent;\n  splines=true;\n  nodesep=1;\n  node [fontsize=18, shape=rect, color=\"#dbc3b6\", style=filled];\n";
+print_endline ("  " ^ !style);
 let graph = graphOfEdges(!dependencies) in
 begin
   match !roots with

--- a/tools/generate-mathcomp-analysis.sh
+++ b/tools/generate-mathcomp-analysis.sh
@@ -16,7 +16,7 @@ FILES=$(find classical/ theories/ reals/ reals_stdlib experimental_reals analysi
 
 coqdep -f _CoqProject > depend.d
 cat -n depend.d >&2
-$DIR/ocamldot/ocamldot depend.d > depend.dot
+$DIR/ocamldot/ocamldot --style "bgcolor=white;\n  splines=true;\n  nodesep=1;\n  node [fontsize=18, shape=rect, color=\"#dbc3b6\", style=filled];" depend.d > depend.dot
 sed -i 's/Classical/mathcomp\.classical/' depend.dot
 sed -i 's/Theories/mathcomp\.analysis/' depend.dot
 sed -i 's/Reals_stdlib/mathcomp\.reals_stdlib/' depend.dot
@@ -32,7 +32,7 @@ $DIR/coq2html -title "MathComp-Analysis($COMMIT_HASH)" -d $OUTDIR -base mathcomp
   -external https://math-comp.github.io/htmldoc_2_1_0/ mathcomp.ssreflect \
   -external https://math-comp.github.io/htmldoc_2_1_0/ mathcomp.algebra \
   -hierarchy-graph "hierarchy-graph.dot" \
-  -dependency-graph "depend.dot" \
+  -dependency-graph "$depend.dot" \
   $FILES
 
 cp hierarchy-graph.dot depend.dot $OUTDIR/


### PR DESCRIPTION
Fixed #67 

Issue-67 has been fixed by introducing a `--style` option to the ocamldot command options to set the background color.