### PR TITLE
CI: Automatically deploy static site for Infotheo

### DIFF
--- a/.github/workflows/deploy_static_site.yml
+++ b/.github/workflows/deploy_static_site.yml
@@ -54,7 +54,9 @@ jobs:
 
       - name: Build Infotheo
         run: cd infotheo/ && opam install -y --deps-only . && opam exec -- make all install
-      - run: opam exec -- tools/generate-infotheo.sh "0.9.1(rocqnavi-${GITHUB_SHA::8})"
+      - run: |
+             opam exec -- tools/generate-infotheo.sh "0.9.1(rocqnavi-${GITHUB_SHA::8})"
+             tree html/
       ## ----------------------------
 
       ## Mathcomp Analysis ----------
@@ -67,7 +69,9 @@ jobs:
 
       - name: Build Mathcomp Analysis
         run: cd analysis/ && opam install -y --deps-only . && opam exec -- make all install
-      - run: opam exec -- tools/generate-mathcomp-analysis.sh "1.9.0(rocqnavi-${GITHUB_SHA::8})"
+      - run: |
+          opam exec -- tools/generate-mathcomp-analysis.sh "1.9.0(rocqnavi-${GITHUB_SHA::8})"
+          tree html/
       ## ----------------------------
 
       - name: Setup Pages
@@ -76,7 +80,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
           path: 'html/'
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy_static_site.yml
+++ b/.github/workflows/deploy_static_site.yml
@@ -27,12 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Clone Mathcomp Analysis
-        uses: actions/checkout@v4
-        with:
-          repository: math-comp/analysis
-          path: analysis
-
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
 
@@ -44,16 +38,37 @@ jobs:
             coq-released: https://coq.inria.fr/opam/released
             default: https://github.com/ocaml/opam-repository.git
 
-      - name: Setup Coq temporary fix for the Dependency Graph
-        run: opam install -y coq.8.20.1
-
-      - name: Build Mathcomp Analysis
-        run: cd analysis/ && opam install -y --deps-only . && opam exec -- make all install
-
       - name: Build coq2html
         run: opam exec -- make
 
-      - run: opam exec -- tools/generate-mathcomp-analysis.sh ${GITHUB_SHA::8}
+      - name: Setup Coq temporary fix for the Dependency Graph
+        run: opam install -y coq.8.20.1
+
+      ## Infotheo -------------------
+      - name: Clone Infotheo
+        uses: actions/checkout@v4
+        with:
+          repository: affeldt-aist/infotheo
+          path: infotheo
+          ref: 0.9.1
+
+      - name: Build Infotheo
+        run: cd infotheo/ && opam install -y --deps-only . && opam exec -- make all install
+      - run: opam exec -- tools/generate-infotheo.sh "0.9.1(rocqnavi-${GITHUB_SHA::8})"
+      ## ----------------------------
+
+      ## Mathcomp Analysis ----------
+      - name: Clone Mathcomp Analysis
+        uses: actions/checkout@v4
+        with:
+          repository: math-comp/analysis
+          path: analysis
+          ref: 1.9.0
+
+      - name: Build Mathcomp Analysis
+        run: cd analysis/ && opam install -y --deps-only . && opam exec -- make all install
+      - run: opam exec -- tools/generate-mathcomp-analysis.sh "1.9.0(rocqnavi-${GITHUB_SHA::8})"
+      ## ----------------------------
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy_static_site.yml
+++ b/.github/workflows/deploy_static_site.yml
@@ -44,20 +44,8 @@ jobs:
       - name: Setup Coq temporary fix for the Dependency Graph
         run: opam install -y coq.8.20.1
 
-      ## Infotheo -------------------
-      - name: Clone Infotheo
-        uses: actions/checkout@v4
-        with:
-          repository: affeldt-aist/infotheo
-          path: infotheo
-          ref: 0.9.1
-
-      - name: Build Infotheo
-        run: cd infotheo/ && opam install -y --deps-only . && opam exec -- make all install
-      - run: |
-             opam exec -- tools/generate-infotheo.sh "0.9.1(rocqnavi-${GITHUB_SHA::8})"
-             tree html/
-      ## ----------------------------
+      - name: top site
+        run: mkdir html && cp -r .github/workflows/resources/* html/
 
       ## Mathcomp Analysis ----------
       - name: Clone Mathcomp Analysis
@@ -72,6 +60,21 @@ jobs:
       - run: |
           opam exec -- tools/generate-mathcomp-analysis.sh "1.9.0(rocqnavi-${GITHUB_SHA::8})"
           tree html/
+      ## ----------------------------
+
+      ## Infotheo -------------------
+      - name: Clone Infotheo
+        uses: actions/checkout@v4
+        with:
+          repository: affeldt-aist/infotheo
+          path: infotheo
+          ref: 0.9.1
+
+      - name: Build Infotheo
+        run: cd infotheo/ && opam install -y --deps-only . && opam exec -- make all install
+      - run: |
+             opam exec -- tools/generate-infotheo.sh "0.9.1(rocqnavi-${GITHUB_SHA::8})"
+             tree html/
       ## ----------------------------
 
       - name: Setup Pages

--- a/.github/workflows/resources/index.html
+++ b/.github/workflows/resources/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rocqnavi Sample Documents</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      line-height: 1.6;
+      margin: 2em;
+      background-color: #f9f9f9;
+      color: #333;
+    }
+    header {
+      margin-bottom: 2em;
+    }
+    h1 {
+      font-size: 2em;
+      color: #005792;
+    }
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+    }
+    li {
+      margin: 1em 0;
+    }
+    a {
+      text-decoration: none;
+      color: #007acc;
+      font-weight: bold;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    footer {
+      margin-top: 3em;
+      font-size: 0.9em;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Rocqnavi Sample Documents</h1>
+
+    <p>
+      This is a sample documentation site generated using <strong>rocqnavi</strong>, an HTML documentation generator for the <strong>rocq prover</strong>, a proof assistant.
+      Each of the following subdirectories contains documentation for different libraries or projects.
+    </p>
+  </header>
+
+  <main>
+    <ul>
+      <li><a href="analysis/">Mathematical Analysis Library (analysis)</a></li>
+      <li><a href="infotheo/">Information Theory Library (infotheo)</a></li>
+    </ul>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 rocqnavi project. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ which so far has been relying on a fragile combination of coqdoc and sed scripts
 
 ### Examples of documentation generated using this fork of coq2hml:
 
-* [MathComp-Analysis](https://github.com/math-comp/analysis): https://yoshihiro503.github.io/coq2html/
-* [Monae](https://yoshihiro503.github.io/coq2html/monae/): https://yoshihiro503.github.io/coq2html/monae/
-* [CompCert](https://compcert.org/): https://yoshihiro503.github.io/coq2html/compcert/
+* [MathComp-Analysis](https://github.com/math-comp/analysis): https://yoshihiro503.github.io/coq2html/analysis/
+* [Infotheo](https://github.com/affeldt-aist/infotheo): https://yoshihiro503.github.io/coq2html/infotheo/
+* TODO: [Monae](https://yoshihiro503.github.io/coq2html/monae/): https://yoshihiro503.github.io/coq2html/monae/
+* TODO: [CompCert](https://compcert.org/): https://yoshihiro503.github.io/coq2html/compcert/
 
 ## Usage
 

--- a/tools/generate-infotheo.sh
+++ b/tools/generate-infotheo.sh
@@ -18,6 +18,13 @@ coqdep -f _CoqProject > depend.d
 cat -n depend.d >&2
 $DIR/ocamldot/ocamldot --style "bgcolor=white; splines=true; nodesep=1; node [fontsize=18, shape=rect, color=\"#dbc3b6\", style=filled];" depend.d > depend.dot
 
+sed -i 's/Lib/infotheo\.lib/' depend.dot
+sed -i 's/Probability/infotheo\.probability/' depend.dot
+sed -i 's/Infomation_theory/infotheo\.infomation_theory/' depend.dot
+sed -i 's/Ecc_classic/infotheo\.ecc_classic /' depend.dot
+sed -i 's/Ecc_modern/infotheo\.ecc_modern /' depend.dot
+sed -i 's/Robust/infotheo\.robust/' depend.dot
+sed -i 's/Toy_examples/infotheo\.toy_examples/' depend.dot
 sed -i 's/\//\./g' depend.dot
 
 $DIR/coq2html -title "Infotheo ($COMMIT_HASH)" -d $OUTDIR -base infotheo \

--- a/tools/generate-infotheo.sh
+++ b/tools/generate-infotheo.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eux
+PROJECT=./infotheo
+COMMIT_HASH=$1
+DIR=$(pwd `dirname .`)
+OUTDIR=$DIR/html/infotheo
+
+rm -rf $OUTDIR
+mkdir -p $OUTDIR
+
+cd $PROJECT
+
+ls -l
+
+FILES=$(find . -name "*.v" -or -name "*.glob")
+
+coqdep -f _CoqProject > depend.d
+cat -n depend.d >&2
+$DIR/ocamldot/ocamldot --style "bgcolor=white; splines=true; nodesep=1; node [fontsize=18, shape=rect, color=\"#dbc3b6\", style=filled];" depend.d > depend.dot
+
+sed -i 's/\//\./g' depend.dot
+
+$DIR/coq2html -title "Infotheo ($COMMIT_HASH)" -d $OUTDIR -base infotheo \
+  -coqlib https://coq.inria.fr/doc/V8.20.1/stdlib/ \
+  -external https://math-comp.github.io/htmldoc_2_1_0/ mathcomp.ssreflect \
+  -external https://math-comp.github.io/htmldoc_2_1_0/ mathcomp.algebra \
+  -external https://math-comp.github.io/analysis/htmldoc_1_9_0/ mathcomp.analysis \
+  -dependency-graph "depend.dot" \
+  $FILES
+

--- a/tools/generate-mathcomp-analysis.sh
+++ b/tools/generate-mathcomp-analysis.sh
@@ -3,16 +3,16 @@ set -eux
 MATHCOMP_ANALYSIS=./analysis
 COMMIT_HASH=$1
 DIR=$(pwd `dirname .`)
-OUTDIR=$DIR/html
+OUTDIR=$DIR/html/analysis
 
 rm -rf $OUTDIR
-mkdir $OUTDIR
+mkdir -p $OUTDIR
 
 cd $MATHCOMP_ANALYSIS
 
 ls -l
 
-FILES=$(find classical/ theories/ reals/ reals_stdlib experimental_reals analysis_stdlib -name "*.v" -or -name "*.glob")
+FILES=$(find . -name "*.v" -or -name "*.glob")
 
 coqdep -f _CoqProject > depend.d
 cat -n depend.d >&2


### PR DESCRIPTION
Whenever rocqnavi is updated, CI continuously generates and automatically deploys the infotheo html document.

* The HTML for mathcomp analysis used to be placed in `/`, but it has been moved to `/analysis`
* Deploy infotheo HTML to /infotheo
* Modified sample links in README

Deploy to:
* https://yoshihiro503.github.io/coq2html/infotheo/
* https://yoshihiro503.github.io/coq2html/analysis/