### PR TITLE
Setting max width to the content

### DIFF
--- a/rocqnavi.css
+++ b/rocqnavi.css
@@ -58,6 +58,10 @@ div.sidebar ul {
     padding-inline-start: 10px;
 }
 
+div.content {
+  max-width: 80ch;
+}
+
 div.coq, code {
     padding: 1em;
     font-family: "Fira Code", monospace;


### PR DESCRIPTION
Yet another small tweak to the CSS, setting max width to the content improves rendering of documentation. Right now the documentation expands to the full available space, and it doesn't look great with long lines rendered from markdown. The parameter can be tweaked, 80ch enforces that the size should not expand over the 80 char limit, perhaps one can add a few characters of buffer, and even a parameter to customize this value.