### PR TITLE
feat: :hammer: Makefile improvements for issue #118

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,11 @@ clean:
 	rm -f *.o *.cm?
 	$(MAKE) -C ocamldot/ clean
 
-PREFIX=/usr/local
+PREFIX?=/usr/local
 BINDIR=$(PREFIX)/bin
 
 install:
+	mkdir -p $(BINDIR)
 	install $(OUTPUT) $(BINDIR)/$(OUTPUT)
 
 depend:


### PR DESCRIPTION
Fixes [118](https://github.com/affeldt-aist/rocqnavi/issues/118)

The installation destination can now be specified using the PREFIX variable.

```console
PREFIX=/usr make install
```