### PR TITLE
fix: Accept unknown glob kinds

### DIFF
--- a/common.ml
+++ b/common.ml
@@ -84,3 +84,6 @@ let list_group_by f xs =
 
 let list_sort_by f xs =
   List.sort (fun x y -> compare (f x) (f y)) xs
+
+let warn s = prerr_endline ("Warning: " ^ s)
+

--- a/common.mli
+++ b/common.mli
@@ -9,3 +9,5 @@ val grep : string -> string -> bool
 
 val list_group_by : ('a -> 'b) -> 'a list -> ('b * 'a list) list
 val list_sort_by : ('a -> 'b) -> 'a list -> 'a list
+
+val warn : string -> unit

--- a/glob_kind.ml
+++ b/glob_kind.ml
@@ -69,7 +69,10 @@ let of_string = function
   | "prf" -> Other "prf"
   | "abbrev" -> Other "abbrev"
   | "vardef" -> Other "vardef"
-  | other -> failwith (!%"unknown kind: '%s'" other)
+  | "vardefax" -> Other "vardefax"
+  | other ->
+     warn (!%"unknown kind: '%s'" other);
+     Other other
 
 let to_string = function
   | Axiom      -> "ax"
@@ -104,4 +107,7 @@ let to_string = function
   | Other "prf" -> "prf"
   | Other "abbrev" -> "abbrev"
   | Other "vardef" -> "vardef"
-  | Other other -> failwith (!%"unknown kind: '%s'" other)
+  | Other "vardefax" -> "vardefax"
+  | Other other ->
+     warn (!%"unknown kind: '%s'" other);
+     other


### PR DESCRIPTION
Even if an unknown glob kind is encountered, the program does not halt with an error. It only sends a warning and continues processing.

see also: https://github.com/math-comp/analysis/actions/runs/17423807650/job/49466997928?pr=1710