### PR TITLE
:sparkles: Put the link to the source code repository

### DIFF
--- a/generate_index.ml
+++ b/generate_index.ml
@@ -95,16 +95,23 @@ let sidebar_files all_files =
   |> List.map (tag_of_file_path [])
   |> String.concat "\n"
 
-let write_html_file all_files txt filename title =
+let start_html_page ch ?link_to_source title h1 all_files =
+  let open Str in
+  let link_to_source_tag = Option.map (!%{|<a href="%s">source</a>|}) link_to_source |> Option.value ~default:"" in
+  global_replace (regexp_string "$NAME") title Resources.header
+  |> global_replace (regexp_string "$H1") h1
+  |> global_replace (regexp_string "$FILES") (sidebar_files all_files)
+  |> global_replace (regexp_string "$LINK_TO_SOURCE") link_to_source_tag
+  |> output_string ch
+
+let end_html_page ch =
+  output_string ch Resources.footer
+
+let write_html_file ?link_to_source all_files txt filename title =
   let oc = open_out filename in
-  let header =
-    Str.global_replace (Str.regexp "<h1.*</h1>") (!%"<h1>%s</h1>" title) Resources.header
-    |> Str.global_replace (Str.regexp "<title>.*</title>") (!%"<title>%s</title>" title)
-    |> Str.global_replace (Str.regexp_string "$FILES") (sidebar_files all_files)
-  in
-  output_string oc header;
+  start_html_page oc ?link_to_source title title all_files;
   output_string oc txt;
-  output_string oc Resources.footer;
+  end_html_page oc;
   close_out oc
 
 type kind = Global | EntryKind of string
@@ -220,7 +227,7 @@ let html_of_notation scope notation item =
   in
   !%{|<a href="%s">%s</a> [%s, in %s] (%s)|} item.linkname (show notation) (linkname_of_kind item.kind) item.module_ scope
 
-let generate_notation_list output_dir table all_files items =
+let generate_notation_list ?link_to_source output_dir table all_files items =
   let grouped =
     List.map notation_of_item items
     |> Common.list_group_by (fun (scope, not, item) -> scope)
@@ -237,7 +244,7 @@ let generate_notation_list output_dir table all_files items =
   in
   let filename = Filename.concat output_dir notations_html_filename in
   let title = "Notations" in
-  write_html_file all_files body filename title
+  write_html_file ?link_to_source all_files body filename title
 
 let compare_case_insensitive s1 s2 =
   String.(compare (lowercase_ascii s1) (lowercase_ascii s2))
@@ -245,7 +252,7 @@ let compare_case_insensitive s1 s2 =
 (*
  * generate an html file, e.g., mathcomp.classical.functions.html
  *)
-let generate_with_capital output_dir table all_files kind (c, items) =
+let generate_with_capital ?link_to_source output_dir table all_files kind (c, items) =
   let html_of_item item =
     !%{|<a href="%s">%s</a> [%s, in %s]|} item.linkname item.name (linkname_of_kind item.kind) item.module_
   in
@@ -261,7 +268,7 @@ let generate_with_capital output_dir table all_files kind (c, items) =
     let filename = Filename.concat output_dir
         (!%"index_%s_%s.html" (linkname_of_kind kind) (linkname_of_capital c))
     in
-    write_html_file all_files body filename title
+    write_html_file ?link_to_source all_files body filename title
 
 let overwrite_dot_file_with_url xref_table dot_file = (* dirty *)
   let dot_content = String.concat "\n" (Common.read_lines dot_file) in
@@ -322,7 +329,7 @@ let generate_dependency_graph xref_table output_dir dot_file =
 (*
  * generate index.html
  *)
-let generate_topfile output_dir all_files xrefs title xref_table hierarchy_graph_dot_file dependency_dot_file =
+let generate_topfile ?link_to_source output_dir all_files xrefs title xref_table hierarchy_graph_dot_file dependency_dot_file =
   let hierarchy_graph =
     if hierarchy_graph_dot_file = "" then "" else
       generate_hierarchy_graph title xref_table output_dir hierarchy_graph_dot_file
@@ -332,7 +339,7 @@ let generate_topfile output_dir all_files xrefs title xref_table hierarchy_graph
       generate_dependency_graph xref_table output_dir dependency_dot_file
   in
   let body = table xrefs ^ hierarchy_graph ^ dependency_graph in
-  write_html_file all_files body (Filename.concat output_dir "index.html") title
+  write_html_file ?link_to_source all_files body (Filename.concat output_dir "index.html") title
 
 let is_initial init s =
   if s = "" then false else
@@ -376,8 +383,8 @@ let item_of kind module_ path =
   let linkname = !%"%s.html#%s" module_ (sanitize_linkname path) in
   {kind; name=path; linkname; module_}
 
-let generate output_dir (xref_table:XrefTable.t) xref_modules title
-      hierarchy_dot_file dependency_dot_file index_blacklist =
+let generate ?link_to_source output_dir (xref_table:XrefTable.t) xref_modules
+      title hierarchy_dot_file dependency_dot_file index_blacklist =
   let is_blacklisted =
     match index_blacklist with
     | None -> fun name -> false
@@ -425,7 +432,7 @@ let generate output_dir (xref_table:XrefTable.t) xref_modules title
   let all_files = all_files xref_modules in
   let table = table indexed_items in
   List.iter (fun kind ->
-      List.iter (generate_with_capital output_dir table all_files kind) indexed_items)
+      List.iter (generate_with_capital ?link_to_source output_dir table all_files kind) indexed_items)
     kinds;
-  generate_notation_list output_dir table all_files notation_items;
-  generate_topfile output_dir all_files indexed_items title xref_table hierarchy_dot_file dependency_dot_file
+  generate_notation_list ?link_to_source output_dir table all_files notation_items;
+  generate_topfile ?link_to_source output_dir all_files indexed_items title xref_table hierarchy_dot_file dependency_dot_file

--- a/generate_index.ml
+++ b/generate_index.ml
@@ -95,11 +95,12 @@ let sidebar_files all_files =
   |> List.map (tag_of_file_path [])
   |> String.concat "\n"
 
-let start_html_page ch ?link_to_source title h1 all_files =
+let start_html_page ch ?link_to_source title h1 project_name all_files =
   let open Str in
   let link_to_source_tag = Option.map (!%{|<a href="%s">source</a>|}) link_to_source |> Option.value ~default:"" in
   global_replace (regexp_string "$NAME") title Resources.header
   |> global_replace (regexp_string "$H1") h1
+  |> global_replace (regexp_string "$PROJECT") project_name
   |> global_replace (regexp_string "$FILES") (sidebar_files all_files)
   |> global_replace (regexp_string "$LINK_TO_SOURCE") link_to_source_tag
   |> output_string ch
@@ -107,9 +108,9 @@ let start_html_page ch ?link_to_source title h1 all_files =
 let end_html_page ch =
   output_string ch Resources.footer
 
-let write_html_file ?link_to_source all_files txt filename title =
+let write_html_file ?link_to_source all_files txt filename title project_name =
   let oc = open_out filename in
-  start_html_page oc ?link_to_source title title all_files;
+  start_html_page oc ?link_to_source title title project_name all_files;
   output_string oc txt;
   end_html_page oc;
   close_out oc
@@ -227,7 +228,7 @@ let html_of_notation scope notation item =
   in
   !%{|<a href="%s">%s</a> [%s, in %s] (%s)|} item.linkname (show notation) (linkname_of_kind item.kind) item.module_ scope
 
-let generate_notation_list ?link_to_source output_dir table all_files items =
+let generate_notation_list ?link_to_source output_dir proj_name table all_files items =
   let grouped =
     List.map notation_of_item items
     |> Common.list_group_by (fun (scope, not, item) -> scope)
@@ -244,7 +245,7 @@ let generate_notation_list ?link_to_source output_dir table all_files items =
   in
   let filename = Filename.concat output_dir notations_html_filename in
   let title = "Notations" in
-  write_html_file ?link_to_source all_files body filename title
+  write_html_file ?link_to_source all_files body filename title proj_name
 
 let compare_case_insensitive s1 s2 =
   String.(compare (lowercase_ascii s1) (lowercase_ascii s2))
@@ -252,7 +253,7 @@ let compare_case_insensitive s1 s2 =
 (*
  * generate an html file, e.g., mathcomp.classical.functions.html
  *)
-let generate_with_capital ?link_to_source output_dir table all_files kind (c, items) =
+let generate_with_capital ?link_to_source output_dir proj_name table all_files kind (c, items) =
   let html_of_item item =
     !%{|<a href="%s">%s</a> [%s, in %s]|} item.linkname item.name (linkname_of_kind item.kind) item.module_
   in
@@ -268,7 +269,7 @@ let generate_with_capital ?link_to_source output_dir table all_files kind (c, it
     let filename = Filename.concat output_dir
         (!%"index_%s_%s.html" (linkname_of_kind kind) (linkname_of_capital c))
     in
-    write_html_file ?link_to_source all_files body filename title
+    write_html_file ?link_to_source all_files body filename title proj_name
 
 let overwrite_dot_file_with_url xref_table dot_file = (* dirty *)
   let dot_content = String.concat "\n" (Common.read_lines dot_file) in
@@ -339,7 +340,7 @@ let generate_topfile ?link_to_source output_dir all_files xrefs title xref_table
       generate_dependency_graph xref_table output_dir dependency_dot_file
   in
   let body = table xrefs ^ hierarchy_graph ^ dependency_graph in
-  write_html_file ?link_to_source all_files body (Filename.concat output_dir "index.html") title
+  write_html_file ?link_to_source all_files body (Filename.concat output_dir "index.html") title title
 
 let is_initial init s =
   if s = "" then false else
@@ -432,7 +433,7 @@ let generate ?link_to_source output_dir (xref_table:XrefTable.t) xref_modules
   let all_files = all_files xref_modules in
   let table = table indexed_items in
   List.iter (fun kind ->
-      List.iter (generate_with_capital ?link_to_source output_dir table all_files kind) indexed_items)
+      List.iter (generate_with_capital ?link_to_source output_dir title table all_files kind) indexed_items)
     kinds;
-  generate_notation_list ?link_to_source output_dir table all_files notation_items;
+  generate_notation_list ?link_to_source output_dir title table all_files notation_items;
   generate_topfile ?link_to_source output_dir all_files indexed_items title xref_table hierarchy_dot_file dependency_dot_file

--- a/generate_index.mli
+++ b/generate_index.mli
@@ -19,7 +19,7 @@ val all_files : (string, unit) Hashtbl.t -> file_path list
 val sidebar_files : file_path list -> string
 val end_html_page : out_channel -> unit
 
-val start_html_page : out_channel -> ?link_to_source:string -> string -> string -> file_path list -> unit
+val start_html_page : out_channel -> ?link_to_source:string -> string -> string -> string -> file_path list -> unit
 val generate : ?link_to_source:string -> string -> XrefTable.t
                -> (string, unit) Hashtbl.t -> string
                -> string -> string -> Index_blacklist.t option -> unit

--- a/generate_index.mli
+++ b/generate_index.mli
@@ -17,6 +17,9 @@ val sanitize_linkname : string -> string
 type file_path
 val all_files : (string, unit) Hashtbl.t -> file_path list
 val sidebar_files : file_path list -> string
+val end_html_page : out_channel -> unit
 
-val generate : string -> XrefTable.t -> (string, unit) Hashtbl.t -> string
+val start_html_page : out_channel -> ?link_to_source:string -> string -> string -> file_path list -> unit
+val generate : ?link_to_source:string -> string -> XrefTable.t
+               -> (string, unit) Hashtbl.t -> string
                -> string -> string -> Index_blacklist.t option -> unit

--- a/rocqnavi.header
+++ b/rocqnavi.header
@@ -3,8 +3,8 @@
 
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Module $NAME</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<title>$NAME</title>
+<meta name="description" content="Documentation of Coq module $PROJECT" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>

--- a/rocqnavi.header
+++ b/rocqnavi.header
@@ -26,5 +26,8 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1 class="title">Module $NAME</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        $LINK_TO_SOURCE
+      </p>
+      <h1 class="title">$H1</h1>

--- a/rocqnavi.mll
+++ b/rocqnavi.mll
@@ -452,14 +452,6 @@ let end_proof spaces kwd =
 let global_replace re subst txt =
   Str.global_substitute re (fun _ -> subst) txt
 
-let start_html_page modname all_files =
-  global_replace (Str.regexp "\\$NAME") modname Resources.header
-  |> global_replace (Str.regexp_string "$FILES") (sidebar_files all_files)
-  |> output_string !oc
-
-let end_html_page () =
-  output_string !oc Resources.footer
-
 let env : Env.t ref = ref Env.default
 }
 
@@ -773,8 +765,9 @@ let dependency_graph_dot_file = ref ""
 let index_blacklist_file = ref ""
 let show_type_information_using_coqtop_process = ref false
 let show_type_information_using_rocq_lsp_process = ref false
+let link_to_source = ref ""
 
-let process_v_file env all_files f =
+let process_v_file ?link_to_source env all_files f =
   let pref_f = Filename.chop_suffix f ".v" in
   let base_f = Filename.basename pref_f in
   let module_name = !logical_name_base ^ module_name_of_file_name pref_f in
@@ -785,11 +778,11 @@ let process_v_file env all_files f =
   let ic = open_in f in
   oc := open_out (Filename.concat !output_dir (module_name ^ ".html"));
   enum_depth := 0; in_proof := false;
-  start_html_page friendly_name all_files;
+  Generate_index.start_html_page !oc ?link_to_source friendly_name ("Module " ^ friendly_name) all_files;
   let lexbuf = Lexing.from_channel ~with_positions:true ic in
   Lexing.set_filename lexbuf filepath;
   coq_bol lexbuf;
-  end_html_page();
+  Generate_index.end_html_page !oc;
   close_out !oc; oc := stdout;
   close_in ic;
   Option.iter (Type_lookup.close_file filepath module_name) env.type_lookup;
@@ -866,6 +859,8 @@ let () =
       "   Show type information of definitions as a tooltip (consider using -show-type-infomation-using-rocq-lsp)";
     "-show-type-information-using-rocq-lsp", Arg.Set show_type_information_using_rocq_lsp_process,
       "   Show type information of definitions as a tooltip";
+    "-link-to-source", Arg.Set_string link_to_source,
+      "   The Link to the source repository";
   ])
   process_file
   "Usage: rocqnavi [options] file.glob ... file.v ...\nOptions are:";
@@ -897,6 +892,12 @@ let () =
     if !index_blacklist_file = "" then None
     else Some (Index_blacklist.from_file !index_blacklist_file)
   in
+  let link_to_source = if !link_to_source = "" then None else Some !link_to_source in
+  write_file Resources.js (Filename.concat !output_dir "rocqnavi.js");
+  if !generate_css then
+    write_file Resources.css (Filename.concat !output_dir "rocqnavi.css");
+  Generate_index.generate ?link_to_source !output_dir !xref_table xref_modules !title
+    !hierarchy_graph_dot_file !dependency_graph_dot_file index_blacklist_opt;
   if !show_type_information_using_coqtop_process
      || !show_type_information_using_rocq_lsp_process then
     let method_ = if !show_type_information_using_coqtop_process then
@@ -905,12 +906,7 @@ let () =
     in
     Type_lookup.using method_ (fun conn ->
         env := Env.{type_lookup=Some conn; definition_blacklist=index_blacklist_opt;};
-        List.iter (process_v_file !env all_files) (List.rev !v_files))
+        List.iter (process_v_file ?link_to_source !env all_files) (List.rev !v_files))
   else
-    List.iter (process_v_file !env all_files) (List.rev !v_files);
-  Generate_index.generate !output_dir !xref_table xref_modules !title
-    !hierarchy_graph_dot_file !dependency_graph_dot_file index_blacklist_opt;
-  write_file Resources.js (Filename.concat !output_dir "rocqnavi.js");
-  if !generate_css then
-    write_file Resources.css (Filename.concat !output_dir "rocqnavi.css")
+    List.iter (process_v_file ?link_to_source !env all_files) (List.rev !v_files)
 }

--- a/rocqnavi.mll
+++ b/rocqnavi.mll
@@ -767,7 +767,7 @@ let show_type_information_using_coqtop_process = ref false
 let show_type_information_using_rocq_lsp_process = ref false
 let link_to_source = ref ""
 
-let process_v_file ?link_to_source env all_files f =
+let process_v_file ?link_to_source proj_name env all_files f =
   let pref_f = Filename.chop_suffix f ".v" in
   let base_f = Filename.basename pref_f in
   let module_name = !logical_name_base ^ module_name_of_file_name pref_f in
@@ -775,10 +775,11 @@ let process_v_file ?link_to_source env all_files f =
   Option.iter (Type_lookup.open_file filepath module_name) env.type_lookup;
   current_module := module_name;
   let friendly_name = if !use_short_names then base_f else module_name in
+  let title = "Module " ^ friendly_name in
   let ic = open_in f in
   oc := open_out (Filename.concat !output_dir (module_name ^ ".html"));
   enum_depth := 0; in_proof := false;
-  Generate_index.start_html_page !oc ?link_to_source friendly_name ("Module " ^ friendly_name) all_files;
+  Generate_index.start_html_page !oc ?link_to_source title title proj_name all_files;
   let lexbuf = Lexing.from_channel ~with_positions:true ic in
   Lexing.set_filename lexbuf filepath;
   coq_bol lexbuf;
@@ -906,7 +907,7 @@ let () =
     in
     Type_lookup.using method_ (fun conn ->
         env := Env.{type_lookup=Some conn; definition_blacklist=index_blacklist_opt;};
-        List.iter (process_v_file ?link_to_source !env all_files) (List.rev !v_files))
+        List.iter (process_v_file ?link_to_source !title !env all_files) (List.rev !v_files))
   else
-    List.iter (process_v_file ?link_to_source !env all_files) (List.rev !v_files)
+    List.iter (process_v_file ?link_to_source !title !env all_files) (List.rev !v_files)
 }

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+set -e
 test/test1/run.bash
 test/test_type_tooltip/run.bash
 

--- a/test/test1/expected_html/Main.html
+++ b/test/test1/expected_html/Main.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>Module Main</title>
-<meta name="description" content="Documentation of Coq module Main" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>

--- a/test/test1/expected_html/Main.html
+++ b/test/test1/expected_html/Main.html
@@ -27,7 +27,10 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
+      <p>
+        <a href="./index.html">Top</a>
+
+      </p>
       <h1 class="title">Module Main</h1>
 <span class="vernacular">Require</span><span class="vernacular"> Import</span><span class="id"> </span><span class="id"><a href="https://rocq-prover.org/stdlib/Stdlib.Strings.String.html">String</a></span>.<br/>
 <br/>

--- a/test/test1/expected_html/index.html
+++ b/test/test1/expected_html/index.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>test1</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -28,7 +28,7 @@
 
     <div class="content">
       <p><a href="./index.html">Top</a></p>
-      <h1>test1</h1>
+      <h1 class="title">test1</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index.html
+++ b/test/test1/expected_html/index.html
@@ -27,7 +27,10 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
+      <p>
+        <a href="./index.html">Top</a>
+
+      </p>
       <h1 class="title">test1</h1>
 <table><tbody>
 <tr><td>Files</td>

--- a/test/test1/expected_html/index_abbrev_M.html
+++ b/test/test1/expected_html/index_abbrev_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_abbrev_X.html
+++ b/test/test1/expected_html/index_abbrev_X.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>X (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>X (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">X (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_def_M.html
+++ b/test/test1/expected_html/index_def_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_def_X.html
+++ b/test/test1/expected_html/index_def_X.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>X (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>X (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">X (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_file_M.html
+++ b/test/test1/expected_html/index_file_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_file_X.html
+++ b/test/test1/expected_html/index_file_X.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>X (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>X (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">X (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_global_M.html
+++ b/test/test1/expected_html/index_global_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_global_X.html
+++ b/test/test1/expected_html/index_global_X.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>X (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>X (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">X (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_prf_M.html
+++ b/test/test1/expected_html/index_prf_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/expected_html/index_prf_X.html
+++ b/test/test1/expected_html/index_prf_X.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>X (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test1" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>X (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">X (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test1/run.bash
+++ b/test/test1/run.bash
@@ -24,7 +24,7 @@ do
     if type xq > /dev/null 2>&1; then
         diff <(xq $exp_html) <(xq $act_html)
     else
-        diff $exp_html $act_html
+        diff -w $exp_html $act_html
     fi
 done
 

--- a/test/test_type_tooltip/expected_html/Main.html
+++ b/test/test_type_tooltip/expected_html/Main.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>Module Main</title>
-<meta name="description" content="Documentation of Coq module Main" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>

--- a/test/test_type_tooltip/expected_html/Main.html
+++ b/test/test_type_tooltip/expected_html/Main.html
@@ -27,7 +27,10 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
+      <p>
+        <a href="./index.html">Top</a>
+
+      </p>
       <h1 class="title">Module Main</h1>
 <span class="vernacular">Definition</span><span class="id"> </span><span id="aiueo" class="id"><a name="aiueo" class=" tooltip">aiueo<span class="tooltip-area markdown">```coq
 aiueo: nat

--- a/test/test_type_tooltip/expected_html/index.html
+++ b/test/test_type_tooltip/expected_html/index.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>test_type_tooltip</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -28,7 +28,7 @@
 
     <div class="content">
       <p><a href="./index.html">Top</a></p>
-      <h1>test_type_tooltip</h1>
+      <h1 class="title">test_type_tooltip</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index.html
+++ b/test/test_type_tooltip/expected_html/index.html
@@ -27,7 +27,10 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
+      <p>
+        <a href="./index.html">Top</a>
+
+      </p>
       <h1 class="title">test_type_tooltip</h1>
 <table><tbody>
 <tr><td>Files</td>

--- a/test/test_type_tooltip/expected_html/index_abbrev_A.html
+++ b/test/test_type_tooltip/expected_html/index_abbrev_A.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>A (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>A (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">A (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_abbrev_E.html
+++ b/test/test_type_tooltip/expected_html/index_abbrev_E.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>E (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>E (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">E (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_abbrev_H.html
+++ b/test/test_type_tooltip/expected_html/index_abbrev_H.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>H (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>H (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">H (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_abbrev_K.html
+++ b/test/test_type_tooltip/expected_html/index_abbrev_K.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>K (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>K (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">K (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_abbrev_M.html
+++ b/test/test_type_tooltip/expected_html/index_abbrev_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Abbreviations)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Abbreviations)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Abbreviations)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_def_A.html
+++ b/test/test_type_tooltip/expected_html/index_def_A.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>A (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>A (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">A (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_def_E.html
+++ b/test/test_type_tooltip/expected_html/index_def_E.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>E (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>E (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">E (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_def_H.html
+++ b/test/test_type_tooltip/expected_html/index_def_H.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>H (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>H (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">H (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_def_K.html
+++ b/test/test_type_tooltip/expected_html/index_def_K.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>K (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>K (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">K (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_def_M.html
+++ b/test/test_type_tooltip/expected_html/index_def_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Definitions)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Definitions)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Definitions)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_file_A.html
+++ b/test/test_type_tooltip/expected_html/index_file_A.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>A (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>A (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">A (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_file_E.html
+++ b/test/test_type_tooltip/expected_html/index_file_E.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>E (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>E (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">E (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_file_H.html
+++ b/test/test_type_tooltip/expected_html/index_file_H.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>H (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>H (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">H (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_file_K.html
+++ b/test/test_type_tooltip/expected_html/index_file_K.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>K (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>K (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">K (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_file_M.html
+++ b/test/test_type_tooltip/expected_html/index_file_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Files)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Files)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Files)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_global_A.html
+++ b/test/test_type_tooltip/expected_html/index_global_A.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>A (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>A (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">A (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_global_E.html
+++ b/test/test_type_tooltip/expected_html/index_global_E.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>E (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>E (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">E (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_global_H.html
+++ b/test/test_type_tooltip/expected_html/index_global_H.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>H (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>H (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">H (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_global_K.html
+++ b/test/test_type_tooltip/expected_html/index_global_K.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>K (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>K (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">K (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_global_M.html
+++ b/test/test_type_tooltip/expected_html/index_global_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Global Index)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Global Index)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Global Index)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_notations.html
+++ b/test/test_type_tooltip/expected_html/index_notations.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>Notations</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>Notations</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">Notations</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_prf_A.html
+++ b/test/test_type_tooltip/expected_html/index_prf_A.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>A (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>A (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">A (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_prf_E.html
+++ b/test/test_type_tooltip/expected_html/index_prf_E.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>E (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>E (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">E (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_prf_H.html
+++ b/test/test_type_tooltip/expected_html/index_prf_H.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>H (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>H (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">H (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_prf_K.html
+++ b/test/test_type_tooltip/expected_html/index_prf_K.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>K (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>K (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">K (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/expected_html/index_prf_M.html
+++ b/test/test_type_tooltip/expected_html/index_prf_M.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>M (Lemmas)</title>
-<meta name="description" content="Documentation of Coq module $NAME" />
+<meta name="description" content="Documentation of Coq module test_type_tooltip" />
 <link  rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
 <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
@@ -27,8 +27,11 @@
   <div class="coq">
 
     <div class="content">
-      <p><a href="./index.html">Top</a></p>
-      <h1>M (Lemmas)</h1>
+      <p>
+        <a href="./index.html">Top</a>
+        
+      </p>
+      <h1 class="title">M (Lemmas)</h1>
 <table><tbody>
 <tr><td>Files</td>
 <td>A</td><td>B</td><td>C</td><td>D</td><td>E</td><td>F</td><td>G</td><td>H</td><td>I</td><td>J</td><td>K</td><td>L</td><td><a href="index_file_M.html">M</a></td><td>N</td><td>O</td><td>P</td><td>Q</td><td>R</td><td>S</td><td>T</td><td>U</td><td>V</td><td>W</td><td>X</td><td>Y</td><td>Z</td><td>_</td></tr>

--- a/test/test_type_tooltip/run.bash
+++ b/test/test_type_tooltip/run.bash
@@ -26,7 +26,7 @@ do
     if type xq > /dev/null 2>&1; then
         diff <(xq $exp_html) <(xq $act_html)
     else
-        diff $exp_html $act_html
+        diff -w $exp_html $act_html
     fi
 done
 


### PR DESCRIPTION
Resolved: https://github.com/affeldt-aist/rocqnavi/issues/132
Put the link to the source code repository when the `-link-to-source` <URL> is given.

* Introduce a new option `-link-to-source <URL>`
* If the url is given then the all headers of the page has the link