### PR TITLE
feat: 🕜 Set a timeout for the coqtop process

### DIFF
--- a/command.ml
+++ b/command.ml
@@ -21,6 +21,14 @@ let read_available ?(max=4096) ch =
     end
   else None
 
+let input_line_with_timeout timeout_sec ch =
+  let fd = Unix.descr_of_in_channel ch in
+  let ready, _, _ = Unix.select [fd] [] [] timeout_sec in
+  if ready = [] then (* Timeout *)
+    None
+  else
+    Some (input_line ch)
+
 let show_errors (i, o, e) =
   match read_available e with
   | Some msg -> Log.warn msg

--- a/command.mli
+++ b/command.mli
@@ -1,3 +1,4 @@
 val using : string -> (in_channel * out_channel * in_channel -> 'a) -> 'a
 val send : out_channel -> string -> unit
 val read_available : ?max:int -> in_channel -> string option
+val input_line_with_timeout : float -> in_channel -> string option

--- a/coqtop_command.ml
+++ b/coqtop_command.ml
@@ -8,22 +8,29 @@ let parse_prompt line =
   try
     Some (Scanf.sscanf line "<prompt>%s < %d || %d < </prompt>" (fun s a b -> s))
   with
-  | Scanf.Scan_failure msg -> None
+  | Scanf.Scan_failure msg ->
+     Log.debug (!%"Coqtop_command.parse_prompt Scan_failure: '%s'" msg); None
   | End_of_file -> None
 
-let wait_prompt e =
-  let rec iter store =
-    let line = input_line e in (*block*)
-    match parse_prompt line with
-    | Some p -> ()
-    | None   -> iter store
+let wait_prompt ?(msg="") e =
+  let rec iter max_count store =
+    if max_count <= 0 then Log.warn (!%"Coqtop_command Max loop: %s" msg) else
+    (* wait the response *)
+    let timeout_sec = 10. in
+    match Command.input_line_with_timeout timeout_sec e with
+    | Some line ->
+       begin match parse_prompt line with
+       | Some p -> ()
+       | None   -> iter (max_count - 1) store
+       end
+    | None -> Log.warn (!%"Coqtop_command Timeout: %s" msg)
   in
-  iter []
+  iter 100 []
 
 let send ?(wait=0.05) (i, o, e) coq_command =
   prerr_string (!%"Coqtop_command: %s" coq_command); flush stderr;
   Command.send o coq_command; flush o;
-  wait_prompt e;
+  wait_prompt ~msg:coq_command e;
   match Command.read_available i with
   | None -> Error "empty response from coq"
   | Some res ->


### PR DESCRIPTION
This resolves the issue where problems on MathComp Analysis reach a timeout after more than 6 hours of continuous integration.