### PR TITLE
CI: build rocq for 9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
           - macos-latest
 #          - windows-latest
         ocaml-compiler:
-          - "5.5"
+          - "5.2"
           - "4.14"
-        coq_version:
+        rocq_version:
           - "9.0.0"
-#          - "9.1.1"
+          - "9.1.1"
         exclude:
           - ocaml-compiler: "5.5"
-            coq_version: "9.0.0"
+            rocq_version: "9.0.0"
 
     runs-on: ${{ matrix.os }}
 
@@ -47,7 +47,8 @@ jobs:
 
       - name: Set-up Rocq for testing
         run: |
-          opam install -y . coq.${{ matrix.coq_version }} --deps-only --with-test
+          opam install -y rocq-core.${{ matrix.rocq_version }} rocq-stdlib
+          opam install -y . --deps-only --with-test
 
       - name: Build
         run: opam exec -- make all
@@ -58,5 +59,5 @@ jobs:
       - name: Upload the test results as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: test-${{ matrix.os }}-ocaml.${{ matrix.ocaml-compiler }}-coq.${{ matrix.coq_version }}
+          name: test-${{ matrix.os }}-ocaml.${{ matrix.ocaml-compiler }}-rocq.${{ matrix.rocq_version }}
           path: test

--- a/test/hb/run.bash
+++ b/test/hb/run.bash
@@ -10,7 +10,7 @@ mkdir $DIR/html
 
 cd $DIR
 VFiles="*.v"
-coqc $VFiles
+rocq compile $VFiles
 
 GlobFiles="*.glob"
 $RocqNavi -title "test-hb" -d ./html $VFiles $GlobFiles \

--- a/test/test1/run.bash
+++ b/test/test1/run.bash
@@ -10,7 +10,7 @@ mkdir $DIR/html
 
 cd $DIR
 VFiles="Main.v"
-coqc $VFiles
+rocq compile $VFiles
 
 GlobFiles="Main.glob"
 $RocqNavi -title "test1" -d ./html $VFiles $GlobFiles \

--- a/test/test_type_tooltip/run.bash
+++ b/test/test_type_tooltip/run.bash
@@ -10,7 +10,7 @@ mkdir $DIR/html
 
 cd $DIR
 VFiles="Main.v"
-coqc $VFiles
+rocq compile $VFiles
 
 GlobFiles="Main.glob"
 $RocqNavi -title "test_type_tooltip" -d ./html $VFiles $GlobFiles \

--- a/tools/generate-mathcomp-analysis.sh
+++ b/tools/generate-mathcomp-analysis.sh
@@ -28,7 +28,7 @@ cp hierarchy-graph.dot depend.d $OUTDIR/
 
 
 cd $MATHCOMP_ANALYSIS
-FILES=$(find analysis/topology_theory -name "*.v" -or -name "*.glob")
+FILES=$(find . -name "*.v" -or -name "*.glob")
 
 $DIR/rocqnavi -title "MathComp-Analysis-$REVISION" -d $OUTDIR \
   -debug \
@@ -40,9 +40,10 @@ $DIR/rocqnavi -title "MathComp-Analysis-$REVISION" -d $OUTDIR \
   -Q experimental_reals mathcomp.experimental_reals \
   -Q theories mathcomp.analysis \
   -Q analysis_stdlib mathcomp.analysis_stdlib \
-  -external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.ssreflect \
+  -external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.boot \
   -external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.algebra \
   -external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.order \
+  -external https://math-comp.github.io/htmldoc_2_5_0/ HB \
   -structure-graph $OUTDIR/"hierarchy-graph.dot" \
   -file-graph-from-depend $OUTDIR/"depend.d" \
   -index-blacklist $INDEX_BLACKLIST_FILE \


### PR DESCRIPTION
CI Build for following environments:

* OS: Ubuntu, macOS
* OCaml: 4.14, 5.2
* Rocq(rocq-core): 9.0.0, 9.1.1