### PR TITLE
CI: fix deploy failure: Deploy after generatings

### DIFF
--- a/.github/workflows/deploy_static_site.yml
+++ b/.github/workflows/deploy_static_site.yml
@@ -112,6 +112,7 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/mca2html'
+    needs: generate-deploy
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
Fixes the CI error such as:

```log
Fetching artifact metadata for "github-pages" in this workflow run
Found 0 artifact(s)
Error: Fetching artifact metadata failed. Is githubstatus.com reporting issues with API requests, Pages, or Actions? Please re-run the deployment at a later time.
Error: Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
    at getArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:85:1)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:66:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
```

<img width="1405" height="826" alt="スクリーンショット 2026-07-15 10 51 47" src="https://github.com/user-attachments/assets/5c86dc5f-0b38-4838-b2e1-fe748b1b7fec" />
https://github.com/affeldt-aist/rocqnavi/actions/runs/28926643780/job/85815687850